### PR TITLE
Fix: 로그아웃 유저 팔로우 버튼 삭제 및 북마크 레시피 상세 페이지로 바로 이동으로 수정

### DIFF
--- a/src/pages/users/Profile.jsx
+++ b/src/pages/users/Profile.jsx
@@ -59,11 +59,9 @@ const Profile = () => {
     for (let i = 0; i < myInfo.data?.data?.following.length; i++) {
       const nickname = myInfo.data?.data?.following[i].nickname;
       if (nickname === targetNickname) {
-        console.log("내가 팔로우 한 사람임");
         setIsFollowUser(true);
         return;
       } else {
-        console.log("누군데 너");
         setIsFollowUser(false);
       }
     }
@@ -101,9 +99,6 @@ const Profile = () => {
     mutate(userId);
   };
 
-  // console.log("serverUser: ", serverUser);
-  // console.log("myInfo: ", myInfo);
-
   return (
     <div>
       <div>
@@ -125,7 +120,7 @@ const Profile = () => {
                     </button>
                   </div>
                 )}
-                {!isMyAccount && (
+                {!isMyAccount && myInfo?.data?.data?.nickname && (
                   <div className={isFollowUser ? "follow" : ""}>
                     <button onClick={onClickFollowBtnHandler}>
                       {isFollowUser ? "팔로잉" : "팔로우"}
@@ -218,7 +213,7 @@ const Profile = () => {
                     onClick={() => {
                       setIsBookmarkActive(false);
                     }}
-                    to={`/profile/${recipe.article_recipe.author}`}
+                    to={`/recipe/${recipe.article_recipe_id}`}
                   >
                     <li>
                       <div>


### PR DESCRIPTION
로그아웃 유저 팔로우 버튼 삭제
- 불필요한 동작을 방지하기 위함

북마크 레시피 상세 페이지로 바로 이동으로 수정
- 닉네임 클릭시 이동하는건 팔로우 팔로워 기능에서 구현할 예정